### PR TITLE
Insert likes to tweets and comments APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,30 @@
 # Project Introduction
-This is a twitter-like project. You can signup and login to your account, 
+This is a twitter-like project. You can sign up and login to your account, 
 perform post and view tweets, follow and unfollow your
 friends. 
 
 We use push mode (fanout on write) for newsfeed module.
 
 ## APIs:
-| Functions                 | Method|URL                                                        |
-|---------------------------|-------|-----------------------------------------------------------|
-| Account Login             | POST  | http://localhost/api/accounts/login/                      |   
-| Account Logout            | POST  | http://localhost/api/accounts/logout/                     |
-| Check Account Status      | GET   | http://localhost/api/accounts/login_status/               |
-| Account Register          | POST  | http://localhost/api/accounts/signup/                     |
-| View Tweets               | GET   | http://localhost/api/tweets/?user_id={user_id}            |
-| Post Tweet                | POST  | http://localhost/api/tweets/?user_id={user_id}            |
-| Update Tweet              | PUT   | http://localhost/api/tweets/{tweet_id}/                    |
-| Delete Tweet              | DELETE| http://localhost/api/tweets/{tweet_id}/                    |
-| Retrieve Comment with Tweet| GET  | http://localhost/api/tweets/{tweet_id}/?is_preview={bool}  |
-| View Followings           | GET   | http://localhost/api/friendships/{user_id}/followings/    |
-| View Followers            | GET   | http://localhost/api/friendships/{user_id}/followers/     |    
-| Follow                    | POST  | http://localhost/api/friendships/{user_id}/follow/        |
-| Unfollow                  | POST  | http://localhost/api/friendships/{user_id}/unfollow/      |
-| View Comment for A Tweet  | GET   | http://localhost/api/comments/?tweet_id={tweet_id}        |
-| Post Comment              | POST  | http://localhost/api/comments/?tweet_id={tweet_id}        |
-| Update Comment            | PUT   | http://localhost/api/comments/{comment_id}/               |
-| Delete Comment            | DELETE| http://localhost/api/comments/{comment_id}/               |
+| Functions                 | Method|URL                                                        | Required Parameters       |
+|---------------------------|-------|-----------------------------------------------------------|---------------------------|
+| Account Login             | POST  | http://localhost/api/accounts/login/                      | username, password        |
+| Account Logout            | POST  | http://localhost/api/accounts/logout/                     |                           |
+| Check Account Status      | GET   | http://localhost/api/accounts/login_status/               |                           |
+| Account Register          | POST  | http://localhost/api/accounts/signup/                     | username, password, email |
+| View Tweets               | GET   | http://localhost/api/tweets/?user_id={user_id}            |                           |
+| Post Tweet                | POST  | http://localhost/api/tweets/?user_id={user_id}            | content                   |
+| Update Tweet              | PUT   | http://localhost/api/tweets/{tweet_id}/                   | content                   |
+| Delete Tweet              | DELETE| http://localhost/api/tweets/{tweet_id}/                   |                           |
+| Retrieve Comment with Tweet| GET  | http://localhost/api/tweets/{tweet_id}/?is_preview={bool} |                           |
+| View Followings           | GET   | http://localhost/api/friendships/{user_id}/followings/    |                           |
+| View Followers            | GET   | http://localhost/api/friendships/{user_id}/followers/     |                           |
+| Follow                    | POST  | http://localhost/api/friendships/{user_id}/follow/        |                           |
+| Unfollow                  | POST  | http://localhost/api/friendships/{user_id}/unfollow/      |                           |
+| View Comment for A Tweet  | GET   | http://localhost/api/comments/?tweet_id={tweet_id}        |                           |
+| Post Comment              | POST  | http://localhost/api/comments/?tweet_id={tweet_id}        | content                   |
+| Update Comment            | PUT   | http://localhost/api/comments/{comment_id}/               | content                   |
+| Delete Comment            | DELETE| http://localhost/api/comments/{comment_id}/               |                           |
+| Like                      | POST  | http://localhost/api/likes/                               | content type, object id   |
+| Unlike                    | POST  | http://localhost/api/likes/cancel/                        | content type, object id   |
 

--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -3,14 +3,33 @@ from rest_framework.exceptions import ValidationError
 from comments.models import Comment
 from accounts.api.serializers import UserSerializerForComment
 from tweets.models import Tweet
+from likes.services import LikeService
 
 
 class CommentSerializer(serializers.ModelSerializer):
     user = UserSerializerForComment()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
-        fields = ('id', 'tweet_id', 'user', 'content', 'created_at', 'updated_at',)
+        fields = (
+            'id',
+            'tweet_id',
+            'user',
+            'content',
+            'created_at',
+            'updated_at',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
+
 
 class CommentSerializerForCreate(serializers.ModelSerializer):
     tweet_id = serializers.IntegerField()
@@ -45,10 +64,3 @@ class CommentSerializerForUpdate(serializers.ModelSerializer):
         instance.content = validated_data['content']
         instance.save()
         return instance
-
-class CommentSerializerForTweet(serializers.ModelSerializer):
-    user = UserSerializerForComment()
-
-    class Meta:
-        model = Comment
-        fields = ('id', 'user', 'content', 'created_at', 'updated_at',)

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -28,7 +28,11 @@ class CommentViewSet(viewsets.GenericViewSet):
         queryset = self.get_queryset()
         # to be continued, order by likes count
         comments = self.filter_queryset(queryset).prefetch_related('user').order_by('created_at')
-        serializer = CommentSerializer(comments, many=True)
+        serializer = CommentSerializer(
+            comments,
+            context={'request': request},
+            many=True
+        )
         return Response({
             'success': True,
             'comments': serializer.data,
@@ -48,7 +52,10 @@ class CommentViewSet(viewsets.GenericViewSet):
             }, status=status.HTTP_400_BAD_REQUEST)
 
         comment = serializer.save()
-        return Response(CommentSerializer(comment).data, status=status.HTTP_201_CREATED)
+        return Response(
+            CommentSerializer(comment, context={'request': request}).data,
+            status=status.HTTP_201_CREATED
+        )
 
     def update(self, request, *args, **kwargs):
         # self.get_object() will raise 404 if cannot find the object
@@ -64,7 +71,7 @@ class CommentViewSet(viewsets.GenericViewSet):
 
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_200_OK,
         )
 

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -3,6 +3,10 @@ from utils.testcases import TestCase
 
 LIKE_BASE_URL = '/api/likes/'
 LIKE_CANCEL_URL = '/api/likes/cancel/'
+COMMENT_LIST_API = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_RETRIEVE_API = '/api/tweets/{}/?is_preview={}'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 class LikeApiTests(TestCase):
     
@@ -151,3 +155,66 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(tweet.like_set.count(), 0)
         self.assertEqual(comment.like_set.count(), 0)
+
+    def test_likes_in_comments_api(self):
+        tweet = self.create_tweet(self.user1)
+        comment = self.create_comment(self.user1, tweet)
+
+        # test unauthorized like
+        response = self.anonymous_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+
+        # test list comments with detail
+        response = self.user_client2.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+        self.create_like(self.user2, comment)
+        response = self.user_client2.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 1)
+
+        # test retrieve tweet with detail
+        self.create_like(self.user1, comment)
+        url = TWEET_RETRIEVE_API.format(tweet.id, False)
+        response = self.user_client1.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 2)
+
+    def test_likes_in_tweets_api(self):
+        tweet = self.create_tweet(self.user1)
+
+        # test tweet retrieve api
+        url = TWEET_RETRIEVE_API.format(tweet.id, False)
+        response = self.user_client2.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['has_liked'], False)
+        self.assertEqual(response.data['likes_count'], 0)
+        self.create_like(self.user2, tweet)
+        response = self.user_client2.get(url)
+        self.assertEqual(response.data['has_liked'], True)
+        self.assertEqual(response.data['likes_count'], 1)
+
+        # test tweets list api
+        response = self.user_client2.get(TWEET_LIST_API, {'user_id': self.user1.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
+        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+
+        # test newsfeeds list api
+        self.create_like(self.user1, tweet)
+        self.create_newsfeed(self.user2, tweet)
+        response = self.user_client2.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+
+        # test retrieve tweet with detail
+        url = TWEET_RETRIEVE_API.format(tweet.id, False)
+        response = self.user_client2.get(url)
+        self.assertEqual(len(response.data['likes']), 2)
+        self.assertEqual(response.data['likes'][0]['user']['id'], self.user1.id)
+        self.assertEqual(response.data['likes'][1]['user']['id'], self.user2.id)

--- a/likes/services.py
+++ b/likes/services.py
@@ -1,0 +1,20 @@
+"""
+The reason why services.py is not located under /likes/api/ is
+that LikeService may not only called by APIs. It also may called
+by asynchronous tasks
+"""
+from django.contrib.contenttypes.models import ContentType
+from likes.models import Like
+
+
+class LikeService:
+
+    @classmethod
+    def has_liked(cls, user, target):
+        if user.is_anonymous:
+            return False
+        return Like.objects.filter(
+            content_type=ContentType.objects.get_for_model(target.__class__),
+            object_id=target.id,
+            user=user,
+        ).exists()

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -12,7 +12,12 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user=self.request.user).prefetch_related('user', 'tweet')
 
     def list(self, request):
-        serializer = NewsFeedSerializer(self.get_queryset(), many=True)
+        serializer = NewsFeedSerializer(
+            self.get_queryset(),
+            # for TweetSerializer.get_has_liked()
+            context={'request': request},
+            many=True,
+        )
         return Response({
             'newsfeeds': serializer.data,
         }, status=status.HTTP_200_OK)

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,15 +1,39 @@
 from rest_framework import serializers
 from tweets.models import Tweet
 from accounts.api.serializers import UserSerializerForTweet
-from comments.api.serializers import CommentSerializerForTweet
+from comments.api.serializers import CommentSerializer
+from likes.api.serializers import LikeSerializer
+from likes.services import LikeService
 
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet()
+    comments_count = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'content', 'created_at', 'updated_at')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'updated_at',
+            'content',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_comments_count(self, obj):
+        return obj.comment_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
+
 
 class TweetSerializerForCreate(serializers.ModelSerializer):
     content = serializers.CharField(min_length=6, max_length=255)
@@ -25,7 +49,7 @@ class TweetSerializerForCreate(serializers.ModelSerializer):
         return tweet
 
 
-class TweetSerializerWithComments(TweetSerializer):
+class TweetSerializerWithDetail(TweetSerializer):
     # Adding 'source' equal to
     # add comments property in Tweet model (see tweets/models.py)
     # comments = CommentSerializer(source='comment_set', many=True)
@@ -33,17 +57,37 @@ class TweetSerializerWithComments(TweetSerializer):
 
     # Using SerializerMethodField(), get_comments() is for this.
     comments = serializers.SerializerMethodField()
+    likes = LikeSerializer(source='like_set', many=True)
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'content', 'created_at', 'updated_at', 'comments')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'updated_at',
+            'content',
+            'comments_count',
+            'comments',
+            'likes_count',
+            'likes',
+            'has_liked',
+        )
 
     def get_comments(self, obj):
         # obj is the tweet
         if self.context['is_preview'] == 'true':
-            return CommentSerializerForTweet(obj.comment_set.all()[:3], many=True).data
+            return CommentSerializer(
+                obj.comment_set.all()[:3],
+                context={'request': self.context['request']},
+                many=True
+            ).data
         elif self.context['is_preview'] == 'false':
-            return CommentSerializerForTweet(obj.comment_set.all(), many=True).data
+            return CommentSerializer(
+                obj.comment_set.all(),
+                context={'request': self.context['request']},
+                many=True
+            ).data
 
 
 class TweetSerializerForUpdate(serializers.ModelSerializer):

--- a/utils/testcases.py
+++ b/utils/testcases.py
@@ -5,6 +5,7 @@ from rest_framework.test import APIClient
 from tweets.models import Tweet
 from comments.models import Comment
 from likes.models import Like
+from newsfeeds.models import NewsFeed
 
 class TestCase(DjangoTestCase):
 
@@ -46,3 +47,6 @@ class TestCase(DjangoTestCase):
         client = APIClient()
         client.force_authenticate(user)
         return user, client
+
+    def create_newsfeed(self, user, tweet):
+        return NewsFeed.objects.create(user=user, tweet=tweet)


### PR DESCRIPTION
1. add `has_liked`, `likes_count`, `likes` and `comments_count` fields to according tweet serializers.
2. add `LikeService` to provide `has_liked` property.
3. modified some related functions to adapt the change.
4. unit test for changes.